### PR TITLE
fix: amqp content type according to structured content mode

### DIFF
--- a/cerk_port_amqp/Cargo.toml
+++ b/cerk_port_amqp/Cargo.toml
@@ -15,3 +15,4 @@ serde_json = "1.0"
 lapin = { version= "1.5.0" , features = [] , default-features = false }
 async-global-executor = "1.4.3"
 futures-lite = "1.11.2"
+amq-protocol-types = { version= "6.0.1" }

--- a/cerk_port_amqp/src/port_amqp.rs
+++ b/cerk_port_amqp/src/port_amqp.rs
@@ -1,3 +1,4 @@
+use amq_protocol_types::{AMQPValue, ShortString};
 use cerk::kernel::{BrokerEvent, Config};
 use cerk::runtime::channel::{BoxedReceiver, BoxedSender};
 use cerk::runtime::InternalServerId;
@@ -246,8 +247,12 @@ async fn publish_cloud_event(
                 immediate: false,
             },
             Vec::from(payload.as_str()),
-            BasicProperties::default().with_delivery_mode(2),
-        ) //persistent
+            BasicProperties::default()
+                .with_delivery_mode(2) //persistent
+                .with_content_type(ShortString::from(
+                    "application/cloudevents+json; charset=UTF-8",
+                )),
+        )
         .await?
         .await?;
     Ok(confirmation)
@@ -256,6 +261,13 @@ async fn publish_cloud_event(
 /// This port publishes and/or subscribe CloudEvents to/from an AMQP broker with protocol version v0.9.1.
 ///
 /// The port is implemented with [lapin](https://github.com/CleverCloud/lapin).
+///
+/// # Content Modes
+///
+/// The port supports the structured content mode with the JSON event format.
+/// However, it does not support the binary content mode.
+///
+/// <https://github.com/cloudevents/spec/blob/master/amqp-protocol-binding.md#2-use-of-cloudevents-attributes>
 ///
 /// # Examples
 ///


### PR DESCRIPTION
https://github.com/cloudevents/spec/blob/master/amqp-protocol-binding.md#321-amqp-content-type