### PR TITLE
Release 0.2.8

### DIFF
--- a/cerk/Cargo.toml
+++ b/cerk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerk"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Linus Basig <linus@basig.me>",
     "Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"

--- a/cerk_config_loader_file/Cargo.toml
+++ b/cerk_config_loader_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerk_config_loader_file"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Linus Basig <linus@basig.me>",
     "Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"

--- a/cerk_loader_file/Cargo.toml
+++ b/cerk_loader_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerk_loader_file"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Linus Basig <linus@basig.me>",
     "Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"

--- a/cerk_port_amqp/Cargo.toml
+++ b/cerk_port_amqp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerk_port_amqp"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Linus Basig <linus@basig.me>",
     "Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"

--- a/cerk_port_dummies/Cargo.toml
+++ b/cerk_port_dummies/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerk_port_dummies"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Linus Basig <linus@basig.me>",
     "Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"

--- a/cerk_port_health_check_http/Cargo.toml
+++ b/cerk_port_health_check_http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerk_port_health_check_http"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Linus Basig <linus@basig.me>",
     "Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"

--- a/cerk_port_mqtt/Cargo.toml
+++ b/cerk_port_mqtt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerk_port_mqtt"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Linus Basig <linus@basig.me>",
     "Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"

--- a/cerk_port_mqtt_mosquitto/Cargo.toml
+++ b/cerk_port_mqtt_mosquitto/Cargo.toml
@@ -21,5 +21,5 @@ url = "2"
 cerk = { version = "0.2", path = "../cerk" }
 cloudevents-sdk = "0.3"
 serde_json = "1.0"
-mosquitto-client-wrapper = "0.3"
+mosquitto-client-wrapper = "^0.3.1"
 anyhow = "1.0"

--- a/cerk_port_unix_socket/Cargo.toml
+++ b/cerk_port_unix_socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerk_port_unix_socket"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Linus Basig <linus@basig.me>",
     "Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"

--- a/cerk_router_broadcast/Cargo.toml
+++ b/cerk_router_broadcast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerk_router_broadcast"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Linus Basig <linus@basig.me>",
     "Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"

--- a/cerk_router_rule_based/Cargo.toml
+++ b/cerk_router_rule_based/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerk_router_rule_based"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Linus Basig <linus@basig.me>",
     "Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"

--- a/cerk_runtime_threading/Cargo.toml
+++ b/cerk_runtime_threading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerk_runtime_threading"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Linus Basig <linus@basig.me>",
     "Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"

--- a/examples/examples/Cargo.toml
+++ b/examples/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cerk_examples"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Linus Basig <linus@basig.me>",
     "Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"

--- a/examples/unix_socket_and_mqtt_on_armv7/Cargo.toml
+++ b/examples/unix_socket_and_mqtt_on_armv7/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example_unix_socket_and_mqtt_on_armv7"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     "Linus Basig <linus@basig.me>",
     "Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"


### PR DESCRIPTION
cerk@0.2.8
cerk_config_loader_file@0.2.8
cerk_examples@0.2.8
cerk_loader_file@0.2.8
cerk_port_amqp@0.2.8
cerk_port_dummies@0.2.8
cerk_port_health_check_http@0.2.8
cerk_port_mqtt@0.2.8
cerk_port_mqtt_mosquitto@0.2.8
cerk_port_unix_socket@0.2.8
cerk_router_broadcast@0.2.8
cerk_router_rule_based@0.2.8
cerk_runtime_threading@0.2.8
example_unix_socket_and_mqtt_on_armv7@0.2.8

Generated by cargo-workspaces