### PR TITLE
fix: set serde version to fixed patch

### DIFF
--- a/cerk/Cargo.toml
+++ b/cerk/Cargo.toml
@@ -19,4 +19,4 @@ log = "0.4.0"
 cloudevents-sdk = "0.3.0"
 strum_macros = "0.19.4"
 anyhow = "1.0"
-serde = "1.0.117"
+serde = { version = "=1.0.118" }


### PR DESCRIPTION
the cloudevent-sdk is not compatible with 1.0.119

https://github.com/cloudevents/sdk-rust/issues/109