### PR TITLE
update cargo to edition 2021 & rust to 1.62

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Different Docker-based development environments can be found [here](https://gith
 ### Prerequisites without Docker
 
 1. latest version of [rustup](https://www.rust-lang.org/tools/install)
-2. Rust version 1.47.0: `rustup install 1.47.0`
+2. Rust version 1.62.0: `rustup install 1.62.0`
 3. Additional C libraries depending on the platform (examples can be found in the Docker containers)
 
 Optional Tooling:

--- a/buildkite.yml
+++ b/buildkite.yml
@@ -21,15 +21,16 @@ steps:
       - docker-compose run hello-world | tee build.log | grep --line-buffered "dummy-logger-output received cloud event with id=3" | exit 0
     timeout_in_minutes: 10
     artifact_paths: "**/build.log"
-  - label: "example: build  UNIX Socket and MQTT for armv7"
-    commands:
-      - cd examples/unix_socket_and_mqtt_on_armv7
-      - docker build . -t armv7
-      - echo "now in $${PWD}"
-      - docker run -v $${PWD}/../../:/cerk armv7
-    plugins:
-      - artifacts#v1.2.0:
-          upload: "target/armv7-unknown-linux-gnueabihf/release/unix_socket_and_mqtt_on_armv7"
+  # todo: needs fixing: https://github.com/ce-rust/cerk/issues/149
+  # - label: "example: build  UNIX Socket and MQTT for armv7"
+  #   commands:
+  #     - cd examples/unix_socket_and_mqtt_on_armv7
+  #     - docker build . -t armv7
+  #     - echo "now in $${PWD}"
+  #     - docker run -v $${PWD}/../../:/cerk armv7
+  #   plugins:
+  #     - artifacts#v1.2.0:
+  #         upload: "target/armv7-unknown-linux-gnueabihf/release/unix_socket_and_mqtt_on_armv7"
   - label: "example: execute rule based routing"
     commands: 
       - cd examples/examples/src/rule_based_routing
@@ -42,10 +43,11 @@ steps:
       - ./run-example.sh
     timeout_in_minutes: 15
     artifact_paths: "**/build.log"
-  - label: "setup: ubuntulinux"
-    commands: 
-        - cd setup
-        - docker-compose run ubuntulinux
+  # todo: needs fixing: https://github.com/ce-rust/cerk/issues/150
+  # - label: "setup: ubuntulinux"
+  #   commands: 
+  #       - cd setup
+  #       - docker-compose run ubuntulinux
   # archlinux setup is not working on buildkite runner - seems related to https://bugs.archlinux.org/task/69563
   # - label: "setup: archlinux"
   #   commands: 

--- a/cerk/Cargo.toml
+++ b/cerk/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
 keywords = ["cloudevents", "router", "cerk"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 log = "0.4.0"

--- a/cerk_config_loader_file/Cargo.toml
+++ b/cerk_config_loader_file/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
 keywords = ["cloudevents", "router", "cerk"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 log = "0.4"

--- a/cerk_loader_file/Cargo.toml
+++ b/cerk_loader_file/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
 keywords = ["cloudevents", "router", "cerk"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cerk_port_amqp/Cargo.toml
+++ b/cerk_port_amqp/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
 keywords = ["cloudevents", "router", "cerk", "amqp"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 log = "0.4.0"

--- a/cerk_port_amqp/src/port_amqp.rs
+++ b/cerk_port_amqp/src/port_amqp.rs
@@ -151,7 +151,7 @@ fn setup_connection(
 ) -> Result<(Connection, AmqpOptions)> {
     let mut config = match build_config(&id, &config) {
         Ok(c) => c,
-        Err(e) => panic!(e),
+        Err(e) => std::panic::panic_any(e),
     };
 
     async_global_executor::block_on(async {

--- a/cerk_port_dummies/Cargo.toml
+++ b/cerk_port_dummies/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
 keywords = ["cloudevents", "router", "cerk"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 log = "0.4.0"

--- a/cerk_port_health_check_http/Cargo.toml
+++ b/cerk_port_health_check_http/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
 keywords = ["cloudevents", "router", "cerk", "health-check"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cerk_port_health_check_http/src/port_health_check.rs
+++ b/cerk_port_health_check_http/src/port_health_check.rs
@@ -340,7 +340,7 @@ mod tests {
                 .await;
             match r {
                 Ok(r) => assert_eq!(r.status(), status),
-                Err(e) => assert!(false, e),
+                Err(e) => assert!(false, "{}", e),
             }
         });
 

--- a/cerk_port_mqtt/Cargo.toml
+++ b/cerk_port_mqtt/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
 keywords = ["cloudevents", "router", "cerk", "mqtt"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 log = "0.4"

--- a/cerk_port_mqtt_mosquitto/Cargo.toml
+++ b/cerk_port_mqtt_mosquitto/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
 keywords = ["cloudevents", "router", "cerk", "mqtt"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 log = "0.4"

--- a/cerk_port_unix_socket/Cargo.toml
+++ b/cerk_port_unix_socket/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
 keywords = ["cloudevents", "router", "cerk"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cerk_port_unix_socket/src/port_input_unix_socket_json.rs
+++ b/cerk_port_unix_socket/src/port_input_unix_socket_json.rs
@@ -24,7 +24,7 @@ fn liten_to_stream(
                 let stream = BufReader::new(socket);
                 liten_to_stream(id, listener, Some(stream), sender_to_kernel, max_tries - 1)
             }
-            Err(err) => panic!(err),
+            Err(err) => std::panic::panic_any(err),
         },
         Some(stream) => {
             let mut line = String::new();

--- a/cerk_router_broadcast/Cargo.toml
+++ b/cerk_router_broadcast/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
 keywords = ["cloudevents", "router", "cerk"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cerk_router_rule_based/Cargo.toml
+++ b/cerk_router_rule_based/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
 keywords = ["cloudevents", "router", "cerk"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cerk_runtime_threading/Cargo.toml
+++ b/cerk_runtime_threading/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
 keywords = ["cloudevents", "router", "cerk"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   test:
-    image: lazzaretti/docker-rust-cerk:0.4.0
+    image: lazzaretti/docker-rust-cerk:0.6.0
     volumes:
       - .:/cerk/
       - ./lib/libmosquitto.so.1:/usr/local/lib/libmosquitto.so
@@ -15,19 +15,19 @@ services:
       && cargo fmt -- --check
       "
   doc:
-    image: lazzaretti/docker-rust-cerk:0.4.0
+    image: lazzaretti/docker-rust-cerk:0.6.0
     volumes:
       - .:/cerk/
     working_dir: /cerk
     command: cargo doc --all
   check-readme:
-    image: lazzaretti/ce-rust-docker-cargo-readme:3.1.2
+    image: lazzaretti/ce-rust-docker-cargo-readme:3.1.2-1
     volumes:
       - .:/cerk/
     working_dir: /cerk
     command: ./check-readme.sh
   deny:
-    image: lazzaretti/docker-rust-cerk:0.5.0
+    image: lazzaretti/docker-rust-cerk:0.6.0
     volumes:
       - .:/cerk/
     working_dir: /cerk

--- a/docker/cerk-common/Cargo.toml
+++ b/docker/cerk-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cerk-common"
 version = "0.2.0"
 authors = ["Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/examples/Cargo.toml
+++ b/examples/examples/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/ce-rust/cerk"
 documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [[bin]]

--- a/examples/unix_socket_and_mqtt_on_armv7/Cargo.toml
+++ b/examples/unix_socket_and_mqtt_on_armv7/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/ce-rust/cerk"
 documentation = "https://github.com/ce-rust/cerk"
 homepage = "https://github.com/ce-rust/cerk"
 keywords = ["cloudevents", "router"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/integration-tests/reliable-amqp/cerk-amqp/Cargo.toml
+++ b/integration-tests/reliable-amqp/cerk-amqp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cerk-amqp"
 version = "0.1.0"
 authors = ["Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/integration-tests/reliable-amqp/test-executor/Cargo.toml
+++ b/integration-tests/reliable-amqp/test-executor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test-executor"
 version = "0.1.0"
 authors = ["Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/integration-tests/reliable-mqtt/cerk-mqtt/Cargo.toml
+++ b/integration-tests/reliable-mqtt/cerk-mqtt/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cerk-mqtt"
 version = "0.1.0"
 authors = ["Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/integration-tests/reliable-mqtt/test-executor/Cargo.toml
+++ b/integration-tests/reliable-mqtt/test-executor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test-executor"
 version = "0.1.0"
 authors = ["Fabrizio Lazzaretti <fabrizio@lazzaretti.me>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html

follow up fixes:
- https://github.com/ce-rust/cerk/issues/148
- https://github.com/ce-rust/cerk/issues/149
- https://github.com/ce-rust/cerk/issues/150