### PR TITLE
chore: update rust to 1.72

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Different Docker-based development environments can be found [here](https://gith
 ### Prerequisites without Docker
 
 1. latest version of [rustup](https://www.rust-lang.org/tools/install)
-2. Rust version 1.67.0: `rustup install 1.67.0`
+2. Rust version 1.72.0: `rustup install 1.72`
 3. Additional C libraries depending on the platform (examples can be found in the Docker containers)
 
 Optional Tooling:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   test:
-    image: lazzaretti/docker-rust-cerk:0.7.0
+    image: ghcr.io/ce-rust/rust-cerk:v0.8.0
     volumes:
       - .:/cerk/
       - ./lib/libmosquitto.so.1:/usr/local/lib/libmosquitto.so
@@ -15,19 +15,19 @@ services:
       && cargo fmt -- --check
       "
   doc:
-    image: lazzaretti/docker-rust-cerk:0.7.0
+    image: ghcr.io/ce-rust/rust-cerk:v0.8.0
     volumes:
       - .:/cerk/
     working_dir: /cerk
     command: cargo doc --all
   check-readme:
-    image: lazzaretti/ce-rust-docker-cargo-readme:3.2.0
+    image: ghcr.io/ce-rust/cargo-readme:v3.3.0
     volumes:
       - .:/cerk/
     working_dir: /cerk
     command: ./check-readme.sh
   deny:
-    image: lazzaretti/docker-rust-cerk:0.7.0
+    image: ghcr.io/ce-rust/rust-cerk:v0.8.0
     volumes:
       - .:/cerk/
     working_dir: /cerk

--- a/docker/cerk-common/Dockerfile
+++ b/docker/cerk-common/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 lazzaretti/docker-rust-cerk:0.7.0 as build-env
+FROM --platform=linux/amd64 ghcr.io/ce-rust/rust-cerk:v0.8.0 as build-env
 WORKDIR /app
 
 # add missing libraries, inspired by https://github.com/kyos0109/varnish60-distroless/blob/master/Dockerfile

--- a/examples/examples/src/mqtt/docker-compose.yml
+++ b/examples/examples/src/mqtt/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   cerk-publisher:
-    image: lazzaretti/docker-rust-cerk:0.7.0
+    image: ghcr.io/ce-rust/rust-cerk:v0.8.0
     environment: 
       - RUST_BACKTRACE=1
     volumes:
@@ -14,7 +14,7 @@ services:
     links: 
       - mqtt-broker
   cerk-subscriber:
-    image: lazzaretti/docker-rust-cerk:0.7.0
+    image: ghcr.io/ce-rust/rust-cerk:v0.8.0
     volumes:
       - ../../../../:/cerk/
     working_dir: /cerk/examples/examples

--- a/examples/examples/src/sequence_to_amqp_to_printer/docker-compose.yml
+++ b/examples/examples/src/sequence_to_amqp_to_printer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - 5672:5672
       - 15672:15672
   cerk-consumer:
-    image: lazzaretti/docker-rust-cerk:0.7.0
+    image: ghcr.io/ce-rust/rust-cerk:v0.8.0
     volumes:
       - ../../../../:/cerk/
     working_dir: /cerk
@@ -19,7 +19,7 @@ services:
     links:
       - rabbitmq
   cerk-publisher:
-    image: lazzaretti/docker-rust-cerk:0.7.0
+    image: ghcr.io/ce-rust/rust-cerk:v0.8.0
     volumes:
       - ../../../../:/cerk/
     working_dir: /cerk

--- a/integration-tests/reliable-amqp/docker-compose.yml
+++ b/integration-tests/reliable-amqp/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - 5672:5672
       - 15672:15672
   cerk-amqp:
-    image: lazzaretti/docker-rust-cerk:0.6.0
+    image: ghcr.io/ce-rust/rust-cerk:v0.8.0
     volumes:
       - ../../:/cerk/
     working_dir: /cerk/integration-tests/reliable-amqp/cerk-amqp
@@ -19,7 +19,7 @@ services:
     links:
       - rabbitmq
   test-executor:
-    image: lazzaretti/docker-rust-cerk:0.6.0
+    image: ghcr.io/ce-rust/rust-cerk:v0.8.0
     volumes:
       - ../../:/cerk/
     working_dir: /cerk/integration-tests/reliable-amqp/test-executor

--- a/integration-tests/reliable-mqtt/docker-compose.yml
+++ b/integration-tests/reliable-mqtt/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 1884:1883
   cerk:
-    image: lazzaretti/docker-rust-cerk:0.6.0
+    image: ghcr.io/ce-rust/rust-cerk:v0.8.0
     environment:
       - MOSQUITTO_GIT_URL=https://github.com/ce-rust/mosquitto
       - MOSQUITTO_GIT_HASH=9f834dff9095e6731937d5eac767dbaca46491ac
@@ -29,7 +29,7 @@ services:
       - limited
       - unlimited
   test-executor:
-    image: lazzaretti/docker-rust-cerk:0.6.0
+    image: ghcr.io/ce-rust/rust-cerk:v0.8.0
     volumes:
       - ../../:/cerk/
     working_dir: /cerk/integration-tests/reliable-mqtt/test-executor


### PR DESCRIPTION
- update to rust 1.72
- use docker images from ghcr.io